### PR TITLE
Update sim.py to fix memory blow-up issue from pd.concat()

### DIFF
--- a/vbase_utils/sim.py
+++ b/vbase_utils/sim.py
@@ -116,7 +116,7 @@ def sim(
 
                 # Initialize list for this label if it doesn't exist
                 if label not in results:
-                    results[label] = []
+                    results[label] = {}
 
                 if isinstance(result, pd.Series):
                     # Turn a Series into a DataFrame with the timestamp time index
@@ -124,7 +124,8 @@ def sim(
                 else:
                     # If we have a DataFrame, add the timstamp index.
                     df_result = pd.concat([result], keys=[timestamp], names=["t", None])
-                results[label].append(df_result)
+                df_dict = df_result.to_dict("index")
+                results[label].update(df_dict)
 
         except Exception as e:
             logger.error(
@@ -136,4 +137,7 @@ def sim(
             raise ValueError(f"Error processing timestamp {timestamp}: {str(e)}") from e
 
     # Combine all results into DataFrames
-    return {label: pd.concat(df_list) for label, df_list in results.items()}
+    return {
+        label: pd.DataFrame.from_dict(df_dict, orient="index")
+        for label, df_dict in results.items()
+    }

--- a/vbase_utils/sim.py
+++ b/vbase_utils/sim.py
@@ -114,7 +114,7 @@ def sim(
                         f"got {type(result)} for key '{label}'"
                     )
 
-                # Initialize list for this label if it doesn't exist
+                # Initialize dictionary for this label if it doesn't exist
                 if label not in results:
                     results[label] = {}
 
@@ -124,7 +124,9 @@ def sim(
                 else:
                     # If we have a DataFrame, add the timstamp index.
                     df_result = pd.concat([result], keys=[timestamp], names=["t", None])
+                # Convert result DataFrame to dictionary with row index as key.
                 df_dict = df_result.to_dict("index")
+                # Update the dictionary for this label with the DataFrame dictionary.
                 results[label].update(df_dict)
 
         except Exception as e:


### PR DESCRIPTION
## Summary

Calling pd.concat() creates copies of input DataFrames in memory until garbage collection runs.  This can cause a memory blow-up issue when the number of DataFrames to concatenate is large. The changes in this PR instead create the output DataFrame in one call to avoid creating unnecessary DataFrame copies in memory.

## Acknowledgment

_Mark those which you have done._

- [x] I have performed a **self-review** of my own code.
- [x] I have **tested** the code in my local environment.
- [x] I have **commented my code**, particularly in hard-to-understand areas.

## Checklist

_Mark those which you have done. Remove those which do not apply._

- [x] Existing **Tests** are passing.
- [x] Necessary **Tests** were created or updated.
- [x] Modified **lines of code are formatted**.
