### PR TITLE
Fixed pandas empty concat warning by dropping empty and all-NaN dfs

### DIFF
--- a/vbase_utils/sim.py
+++ b/vbase_utils/sim.py
@@ -136,7 +136,12 @@ def sim(
             raise ValueError(f"Error processing timestamp {timestamp}: {str(e)}") from e
 
     # Combine all results into DataFrames. Use shared memory for concatenation.
+    # Filter out empty and all-NaN DataFrames.
     return {
-        label: pd.concat(df_list, copy=False).copy()
+        label: pd.concat(
+            [df for df in df_list if not df.empty and not df.isna().all().all()],
+            copy=False,
+        ).copy()
         for label, df_list in results.items()
     }
+


### PR DESCRIPTION
## Summary

*Please include a summary of the change.*

## Acknowledgment

_Mark those which you have done._

- [x ] I have performed a **self-review** of my own code.
- [ x] I have **tested** the code in my local environment.
- [ x] I have **commented my code**, particularly in hard-to-understand areas.

## Checklist

_Mark those which you have done. Remove those which do not apply._

- [ ] Existing **Tests** are passing.
- [ ] Necessary **Tests** were created or updated.
- [x] Modified **lines of code are formatted**.
