### PR TITLE
sim() improvements: MultiIndex and callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,55 @@ Create a `.env` file in the project root with the following variables:
    pylint $(git ls-files '*.py')
    ```
 
+## Modules
+
+### `vbase_utils.sim` — Causal time-series simulation
+
+`sim(data, callback, time_index)` drives a forward-only simulation loop that
+guarantees the callback never sees data from the future.
+
+At each timestamp `t` in `time_index`:
+1. Every object in `data` is **masked** to rows where `index <= t`.
+2. DataFrame columns that are **entirely NaN** in the masked window are dropped
+   (so the callback sees only "live" columns — useful for datasets where new
+   features are added over time).
+3. `callback(masked_data)` is called with the masked dict.
+4. Return values (`pd.Series` or `pd.DataFrame`) are accumulated and concatenated
+   into the final result dict.
+
+**Accepted index types**
+
+| Index type | Masking rule |
+|---|---|
+| `DatetimeIndex` | `index <= t` |
+| `MultiIndex` with `DatetimeIndex` as first level | `first_level <= t` (e.g. `(date, symbol)` cross-sectional panels) |
+
+**Example — cross-sectional panel**
+
+```python
+from vbase_utils.sim import sim
+import pandas as pd
+import numpy as np
+
+dates = pd.date_range("2020-01-01", periods=52, freq="W")
+symbols = ["AAPL", "MSFT", "GOOG"]
+mi = pd.MultiIndex.from_product([dates, symbols], names=["date", "symbol"])
+panel = pd.DataFrame({"signal": np.random.randn(len(mi))}, index=mi)
+
+def callback(data):
+    t = data["panel"].index.get_level_values("date").max()
+    xs = data["panel"][data["panel"].index.get_level_values("date") == t]["signal"]
+    xs = xs.copy()
+    xs.index = xs.index.get_level_values("symbol")
+    return {"signal_at_t": xs}
+
+result = sim({"panel": panel}, callback, dates, progress=True)
+
+# result["signal_at_t"] is a wide (52 × 3) DataFrame — dates × symbols.
+# Stack back to (date, symbol) MultiIndex:
+long = result["signal_at_t"].stack(dropna=True).rename_axis(["date", "symbol"])
+```
+
 ## Updating Dependencies
 
 Published runtime dependencies are managed through human-edited ranges in

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Create a `.env` file in the project root with the following variables:
 guarantees the callback never sees data from the future.
 
 At each timestamp `t` in `time_index`:
-1. Every object in `data` is **masked** to rows where `index <= t`.
+1. Every object in `data` is **masked** to rows where `index <= t` (or
+   `first_level <= t` for MultiIndex inputs — see table below).
 2. DataFrame columns that are **entirely NaN** in the masked window are dropped
    (so the callback sees only "live" columns — useful for datasets where new
    features are added over time).

--- a/requirements/lock/dev.txt
+++ b/requirements/lock/dev.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --no-annotate --output-file=requirements/lock/dev.txt --strip-extras requirements/src/dev.in
 #
-astroid==3.2.4 \
-    --hash=sha256:0e14202810b30da1b735827f78f5157be2bbd4a7a59b7707ca0bfc2fb4c0063a \
-    --hash=sha256:413658a61eeca6202a59231abb473f932038fbcbf1666587f66d482083413a25
+astroid==4.0.4 \
+    --hash=sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753 \
+    --hash=sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0
 beautifulsoup4==4.15.0 \
     --hash=sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7 \
     --hash=sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9
@@ -974,9 +974,9 @@ pycparser==3.0 \
 pygments==2.20.0 \
     --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
     --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
-pylint==3.2.7 \
-    --hash=sha256:02f4aedeac91be69fb3b4bea997ce580a4ac68ce58b89eaefeaf06749df73f4b \
-    --hash=sha256:1b7a721b575eaeaa7d39db076b6e7743c993ea44f57979127c517c6c572c803e
+pylint==4.0.6 \
+    --hash=sha256:52f19191bee08bf103f9705ad1a0ece4aa5a0a4ef2bdcbd969375a1e6f6579d5 \
+    --hash=sha256:d11a0e1fdb7b1cd46ec5d6fc78fee8b95f28695b2d6140e5809925f61e32ea54
 pyluach==2.3.0 \
     --hash=sha256:4497b731aef59508b079dbf5f00bc5bf4329ac45090a6cd37b5a83756f0e69ab \
     --hash=sha256:ec6e30669d1df50c9ca160486da44a8195bb4c7a5d3d533990d0c5b03accd281

--- a/requirements/src/dev.in
+++ b/requirements/src/dev.in
@@ -4,5 +4,5 @@
 black>=26.5.1
 matplotlib>=3.7.0
 pre-commit>=3.8.0
-pylint>=3.2.7,<3.3
+pylint>=4.0.6
 PyYAML>=6.0.2

--- a/tests/stats/test_robust_betas.py
+++ b/tests/stats/test_robust_betas.py
@@ -194,7 +194,7 @@ class TestRobustBetas(unittest.TestCase):
         beta_matrix = robust_betas(df_asset_rets, df_fact_rets, half_life=30)
         self.assertTrue(beta_matrix.isna().all().all())
 
-        df_fact_rets_inf, _ = make_single_asset_ret_frames(
+        _, df_fact_rets_inf = make_single_asset_ret_frames(
             self.spy_returns, self.n_timestamps
         )
         df_fact_rets_inf.iloc[10, 0] = np.inf

--- a/tests/stats/test_robust_betas.py
+++ b/tests/stats/test_robust_betas.py
@@ -185,6 +185,22 @@ class TestRobustBetas(unittest.TestCase):
         self.assertTrue(beta_matrix["Asset1"].isna().all())
         self.assertFalse(beta_matrix["Asset2"].isna().all())
 
+    def test_non_finite_factor_returns_all_nan_betas(self):
+        """NaN or inf in any factor row must yield all-NaN betas without raising."""
+        df_asset_rets, df_fact_rets = make_single_asset_ret_frames(
+            self.spy_returns, self.n_timestamps
+        )
+        df_fact_rets.iloc[5, 0] = np.nan
+        beta_matrix = robust_betas(df_asset_rets, df_fact_rets, half_life=30)
+        self.assertTrue(beta_matrix.isna().all().all())
+
+        df_fact_rets_inf, _ = make_single_asset_ret_frames(
+            self.spy_returns, self.n_timestamps
+        )
+        df_fact_rets_inf.iloc[10, 0] = np.inf
+        beta_matrix_inf = robust_betas(df_asset_rets, df_fact_rets_inf, half_life=30)
+        self.assertTrue(beta_matrix_inf.isna().all().all())
+
     def test_with_nan_asset_returns(self):
         """NaN in asset returns must not cause shape mismatch when weighting const column."""
         asset_returns = np.concatenate(

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -57,7 +57,7 @@ class TestSim(unittest.TestCase):
         self.assertEqual(result["values"].iloc[-1]["all"], 555)  # 5 + 50 + 500
 
     def test_invalid_index(self):
-        """Test that non-DatetimeIndex raises ValueError."""
+        """Test that a plain integer Index (neither DatetimeIndex nor MultiIndex) raises ValueError."""
         df = pd.DataFrame({"A": [1, 2, 3]}, index=[1, 2, 3])
         time_index = pd.date_range("2023-01-01", periods=3)
 
@@ -233,6 +233,184 @@ class TestSim(unittest.TestCase):
         self.assertEqual(len(result["result"]), len(self.time_index))
         self.assertTrue(result["result"]["value"].iloc[:2].isna().all())
         self.assertTrue(result["result"]["value"].iloc[2:].notna().all())
+
+
+class TestSimMultiIndex(unittest.TestCase):
+    """Test cases for sim() with MultiIndex (cross-sectional panel) inputs.
+
+    The canonical use-case is a (date, symbol) panel where masking on the first
+    (date) level gives the callback a causal view of the universe at each step.
+    """
+
+    def setUp(self):
+        """Set up a balanced (date, symbol) MultiIndex panel."""
+        self.dates = pd.date_range("2023-01-01", periods=4, freq="W")
+        self.symbols = ["AAPL", "MSFT", "GOOG"]
+        mi = pd.MultiIndex.from_product(
+            [self.dates, self.symbols], names=["date", "symbol"]
+        )
+        n = len(mi)
+        self.panel = pd.DataFrame(
+            {
+                "feature": np.arange(n, dtype=float),
+                "factor": np.ones(n),
+            },
+            index=mi,
+        )
+
+    def test_multiindex_masking_row_count(self):
+        """Callback sees only rows whose first-level date is <= the current timestamp."""
+        n_rows: list[int] = []
+
+        def callback(data: Dict[str, pd.DataFrame | pd.Series]) -> dict:
+            n_rows.append(len(data["panel"]))
+            return {}
+
+        sim({"panel": self.panel}, callback, self.dates)
+
+        n_sym = len(self.symbols)
+        # Each successive timestamp exposes one more week (n_sym rows).
+        self.assertEqual(n_rows, [n_sym * (i + 1) for i in range(len(self.dates))])
+
+    def test_multiindex_masking_excludes_future(self):
+        """No row with a future date is visible in the masked panel."""
+        max_dates_seen: list[pd.Timestamp] = []
+
+        def callback(data: Dict[str, pd.DataFrame | pd.Series]) -> dict:
+            max_dates_seen.append(data["panel"].index.get_level_values("date").max())
+            return {}
+
+        sim({"panel": self.panel}, callback, self.dates)
+
+        for i, seen_max in enumerate(max_dates_seen):
+            self.assertLessEqual(
+                seen_max,
+                self.dates[i],
+                msg=f"At step {i} (timestamp {self.dates[i].date()}), "
+                f"future date {seen_max.date()} appeared in the panel.",
+            )
+
+    def test_multiindex_callback_sees_growing_window(self):
+        """The number of distinct dates in the panel grows by one at each step."""
+        n_dates_visible: list[int] = []
+
+        def callback(data: Dict[str, pd.DataFrame | pd.Series]) -> dict:
+            n_dates_visible.append(
+                data["panel"].index.get_level_values("date").nunique()
+            )
+            return {}
+
+        sim({"panel": self.panel}, callback, self.dates)
+
+        self.assertEqual(n_dates_visible, list(range(1, len(self.dates) + 1)))
+
+    def test_multiindex_result_accumulation_wide(self):
+        """
+        A symbol-indexed Series returned by the callback is accumulated as a row
+        in a wide (date × symbol) DataFrame — one row per timestamp.
+        """
+
+        def callback(
+            data: Dict[str, pd.DataFrame | pd.Series],
+        ) -> Dict[str, pd.Series]:
+            panel = data["panel"]
+            t = panel.index.get_level_values("date").max()
+            xs = panel[panel.index.get_level_values("date") == t]["feature"]
+            xs = xs.copy()
+            xs.index = xs.index.get_level_values("symbol")
+            return {"xs": xs}
+
+        result = sim({"panel": self.panel}, callback, self.dates)
+
+        self.assertIn("xs", result)
+        wide = result["xs"]
+        # Row index = timestamps processed; column index = symbols.
+        self.assertEqual(list(wide.index), list(self.dates))
+        self.assertEqual(sorted(wide.columns.tolist()), sorted(self.symbols))
+
+    def test_multiindex_invalid_first_level_type(self):
+        """MultiIndex whose first level is not a DatetimeIndex raises ValueError."""
+        mi = pd.MultiIndex.from_tuples(
+            [(1, "AAPL"), (1, "MSFT"), (2, "AAPL"), (2, "MSFT")],
+            names=["int_date", "symbol"],
+        )
+        df = pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0]}, index=mi)
+        time_index = pd.date_range("2023-01-01", periods=2)
+
+        def callback(data: Dict[str, pd.DataFrame | pd.Series]) -> dict:
+            return {}
+
+        with self.assertRaisesRegex(ValueError, "first level must be a DatetimeIndex"):
+            sim({"panel": df}, callback, time_index)
+
+    def test_multiindex_dropna_removes_all_nan_column(self):
+        """
+        dropna(axis=1, how='all') applies to MultiIndex DataFrames: a column
+        that is entirely NaN in the masked window is dropped from the data
+        passed to the callback.
+        """
+        n_sym = len(self.symbols)
+        n_dates = len(self.dates)
+        # sparse_col is NaN for the first two date slices, present from date 3 onward.
+        sparse_values = [np.nan] * (n_sym * 2) + [1.0] * (n_sym * (n_dates - 2))
+        df = pd.DataFrame(
+            {
+                "always_present": np.arange(len(self.panel), dtype=float),
+                "sparse_col": sparse_values,
+            },
+            index=self.panel.index,
+        )
+        cols_seen: list[list[str]] = []
+
+        def callback(data: Dict[str, pd.DataFrame | pd.Series]) -> dict:
+            cols_seen.append(sorted(data["panel"].columns.tolist()))
+            return {}
+
+        sim({"panel": df}, callback, self.dates)
+
+        # Dates 0–1: sparse_col is entirely NaN in the masked window → dropped.
+        self.assertEqual(cols_seen[0], ["always_present"])
+        self.assertEqual(cols_seen[1], ["always_present"])
+        # Date 2+: sparse_col has values → retained.
+        self.assertEqual(cols_seen[2], ["always_present", "sparse_col"])
+        self.assertEqual(cols_seen[3], ["always_present", "sparse_col"])
+
+    def test_multiindex_empty_callback_result(self):
+        """A callback that always returns {} leaves the sim() result empty."""
+
+        def callback(data: Dict[str, pd.DataFrame | pd.Series]) -> dict:
+            return {}
+
+        result = sim({"panel": self.panel}, callback, self.dates)
+
+        self.assertEqual(result, {})
+
+    def test_multiindex_mixed_with_datetimeindex(self):
+        """
+        A MultiIndex panel and a plain DatetimeIndex Series can be passed together;
+        each is masked independently by its own index type.
+        """
+        market = pd.Series(
+            np.arange(len(self.dates), dtype=float),
+            index=self.dates,
+            name="market_return",
+        )
+        n_panel_rows: list[int] = []
+        market_vals: list[float] = []
+
+        def callback(data: Dict[str, pd.DataFrame | pd.Series]) -> dict:
+            n_panel_rows.append(len(data["panel"]))
+            market_vals.append(float(data["market"].iloc[-1]))
+            return {}
+
+        sim({"panel": self.panel, "market": market}, callback, self.dates)
+
+        n_sym = len(self.symbols)
+        self.assertEqual(
+            n_panel_rows, [n_sym * (i + 1) for i in range(len(self.dates))]
+        )
+        # market[i] == i (0-based) — each step exposes one more market observation.
+        self.assertEqual(market_vals, list(range(len(self.dates))))
 
 
 if __name__ == "__main__":

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -57,7 +57,7 @@ class TestSim(unittest.TestCase):
         self.assertEqual(result["values"].iloc[-1]["all"], 555)  # 5 + 50 + 500
 
     def test_invalid_index(self):
-        """Test that a plain integer Index (neither DatetimeIndex nor MultiIndex) raises ValueError."""
+        """Test that an integer Index (not DatetimeIndex or MultiIndex) raises ValueError."""
         df = pd.DataFrame({"A": [1, 2, 3]}, index=[1, 2, 3])
         time_index = pd.date_range("2023-01-01", periods=3)
 
@@ -216,6 +216,41 @@ class TestSim(unittest.TestCase):
         self.assertIn("predictions", result)
         self.assertTrue(result["predictions"].empty)
 
+    def test_on_result_streaming_mode(self):
+        """on_result sink is called with the authoritative loop timestamp;
+        sim() returns an empty dict while side effects capture each result."""
+        # Extend time_index one day past the data end so the final loop
+        # timestamp (2023-01-06) differs from the masked data's last row
+        # (2023-01-05), confirming the sink receives the loop timestamp.
+        time_index = pd.DatetimeIndex(
+            list(self.time_index) + [self.time_index[-1] + pd.Timedelta(days=1)]
+        )
+        sink_calls: list[tuple[pd.Timestamp, dict]] = []
+
+        def callback(data: Dict[str, pd.DataFrame | pd.Series]) -> Dict[str, pd.Series]:
+            return {"v": pd.Series([data["df1"]["A"].iloc[-1]], index=["val"])}
+
+        returned = sim(
+            self.sample_data,
+            callback,
+            time_index,
+            on_result=lambda ts, r: sink_calls.append((ts, r)),
+        )
+
+        # (2) Returned dict is empty — nothing is accumulated.
+        self.assertEqual(returned, {})
+        # Sink is called once per timestamp.
+        self.assertEqual(len(sink_calls), len(time_index))
+        for i, (ts, result_dict) in enumerate(sink_calls):
+            # (1) Sink receives the loop timestamp, not masked data's last index.
+            self.assertEqual(ts, time_index[i])
+            self.assertIn("v", result_dict)
+            self.assertIsInstance(result_dict["v"], pd.Series)
+        # At the final step the loop timestamp (2023-01-06) is past the data;
+        # the callback still ran and the sink captured the last data value.
+        self.assertEqual(sink_calls[-1][0], time_index[-1])
+        self.assertEqual(sink_calls[-1][1]["v"].iloc[0], 5.0)
+
     def test_callback_returns_empty_for_early_timestamps(self):
         """Test that empty Series results become NaN rows alongside valid rows."""
         cutoff = self.dates[2]  # 2023-01-03; first 2 timestamps return empty
@@ -337,7 +372,7 @@ class TestSimMultiIndex(unittest.TestCase):
         df = pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0]}, index=mi)
         time_index = pd.date_range("2023-01-01", periods=2)
 
-        def callback(data: Dict[str, pd.DataFrame | pd.Series]) -> dict:
+        def callback(_data: Dict[str, pd.DataFrame | pd.Series]) -> dict:
             return {}
 
         with self.assertRaisesRegex(ValueError, "first level must be a DatetimeIndex"):
@@ -378,7 +413,7 @@ class TestSimMultiIndex(unittest.TestCase):
     def test_multiindex_empty_callback_result(self):
         """A callback that always returns {} leaves the sim() result empty."""
 
-        def callback(data: Dict[str, pd.DataFrame | pd.Series]) -> dict:
+        def callback(_data: Dict[str, pd.DataFrame | pd.Series]) -> dict:
             return {}
 
         result = sim({"panel": self.panel}, callback, self.dates)

--- a/vbase_utils/sim.py
+++ b/vbase_utils/sim.py
@@ -33,7 +33,11 @@ def sim(
 
     Args:
         data: Dictionary mapping labels to pandas DataFrames and/or Series
-            containing time series data. All objects must have a DatetimeIndex.
+            containing time series data.  Each object must have either a
+            DatetimeIndex or a MultiIndex whose *first* level is a DatetimeIndex
+            (e.g. a (date, symbol) cross-sectional panel).  For MultiIndex
+            objects, masking at each timestamp retains all rows whose first-level
+            date is <= that timestamp; the remaining levels are untouched.
         callback: Function that processes the masked data and returns a dictionary of results.
             The function should accept a dictionary of DataFrames/Series and return a dictionary
             mapping labels to DataFrames or Series.
@@ -53,12 +57,24 @@ def sim(
         ValueError: If the callback function doesn't return a dictionary of DataFrames or Series.
         ValueError: If the callback function raises an exception.
     """
-    # Validate input data
+    # Validate input data.
+    # Accepted index types:
+    #   • DatetimeIndex — standard time series (masking: index <= timestamp)
+    #   • MultiIndex whose first level is a DatetimeIndex — cross-sectional panel data
+    #     such as (date, symbol); masking is applied on the first level only, so the
+    #     full row is included whenever its date <= timestamp.
     for label, obj in data.items():
-        if not isinstance(obj.index, pd.DatetimeIndex):
+        if isinstance(obj.index, pd.MultiIndex):
+            if not isinstance(obj.index.levels[0], pd.DatetimeIndex):
+                raise ValueError(
+                    f"Data object '{label}' has a MultiIndex whose first level must be "
+                    f"a DatetimeIndex for time-based masking, "
+                    f"got {type(obj.index.levels[0])}"
+                )
+        elif not isinstance(obj.index, pd.DatetimeIndex):
             raise ValueError(
-                f"Data object '{label}' must have a DatetimeIndex, "
-                f"got {type(obj.index)}"
+                f"Data object '{label}' must have a DatetimeIndex or a MultiIndex "
+                f"with a DatetimeIndex as its first level, got {type(obj.index)}"
             )
 
     # Initialize results dictionary
@@ -74,8 +90,16 @@ def sim(
     for timestamp in iterator:
         try:
             # Mask data for current timestamp.
+            # For MultiIndex data (e.g. panel with (date, symbol) index), mask on the
+            # first level so every row whose date <= timestamp is included.
+            # For ordinary DatetimeIndex data the standard scalar comparison is used.
             masked_data = {
-                label: obj[obj.index <= timestamp] for label, obj in data.items()
+                label: (
+                    obj[obj.index.get_level_values(0) <= timestamp]
+                    if isinstance(obj.index, pd.MultiIndex)
+                    else obj[obj.index <= timestamp]
+                )
+                for label, obj in data.items()
             }
 
             # Note that this masking above does not remove columns
@@ -83,6 +107,10 @@ def sim(
             # Drop pd.DataFrame columns that are all None.
             # This ensures that the callback function only sees the columns
             # that are available at the current timestamp.
+            # For MultiIndex DataFrames the drop still applies: a factor column that
+            # is entirely absent (all NaN) in the masked window is removed.  Callbacks
+            # should guard against this with an active-column check when they rely on
+            # a fixed list of column names (e.g. style_cols).
             masked_data = {
                 label: (
                     obj.dropna(axis=1, how="all")
@@ -145,5 +173,5 @@ def sim(
     # Empty DataFrame results contribute (0, 0) frames that add no rows.
     combined: Dict[str, pd.DataFrame] = {}
     for label, df_list in results.items():
-        combined[label] = pd.concat(df_list, copy=False).copy()
+        combined[label] = pd.concat(df_list).copy()
     return combined

--- a/vbase_utils/sim.py
+++ b/vbase_utils/sim.py
@@ -1,7 +1,7 @@
 """Time-based simulation module for processing time series data."""
 
 import logging
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional
 
 import pandas as pd
 from tqdm import tqdm
@@ -22,6 +22,9 @@ def sim(
     ],
     time_index: pd.DatetimeIndex,
     progress: bool = False,
+    on_result: Optional[
+        Callable[[pd.Timestamp, Dict[str, pd.DataFrame | pd.Series]], None]
+    ] = None,
 ) -> Dict[str, pd.DataFrame]:
     """Simulate processing of time series data using a callback function.
 
@@ -44,6 +47,16 @@ def sim(
         time_index: DatetimeIndex specifying the simulation timestamps.
             The function will process data up to each timestamp in this index.
         progress: Whether to show a progress bar during simulation. Defaults to False.
+        on_result: Optional streaming sink. When provided, it is called as
+            ``on_result(timestamp, result_dict)`` for each timestamp with a
+            non-skipped callback result, and the result is NOT retained or
+            concatenated -- the returned dict is empty. This lets callers write
+            each timestamp's result straight into a preallocated structure and
+            keep peak memory flat instead of holding every per-timestamp frame
+            until the final concat. When None (default), results are accumulated
+            and concatenated as before. The loop timestamp passed here is
+            authoritative (it may differ from the masked data's last index when
+            ``time_index`` is not a subset of the data index).
 
     Returns:
         Dictionary mapping labels to DataFrames containing the concatenated callback
@@ -80,6 +93,14 @@ def sim(
     # Initialize results dictionary
     results: Dict[str, List[pd.DataFrame]] = {}
 
+    # Pre-compute level-0 DatetimeIndex for MultiIndex objects once; it is
+    # invariant across timestamps and get_level_values() is non-trivial.
+    level0: Dict[str, pd.Index] = {
+        label: obj.index.get_level_values(0)
+        for label, obj in data.items()
+        if isinstance(obj.index, pd.MultiIndex)
+    }
+
     # Process each timestamp
     iterator = (
         # Use tqdm to report progress if progress is True.
@@ -95,8 +116,8 @@ def sim(
             # For ordinary DatetimeIndex data the standard scalar comparison is used.
             masked_data = {
                 label: (
-                    obj[obj.index.get_level_values(0) <= timestamp]
-                    if isinstance(obj.index, pd.MultiIndex)
+                    obj[level0[label] <= timestamp]
+                    if label in level0
                     else obj[obj.index <= timestamp]
                 )
                 for label, obj in data.items()
@@ -147,6 +168,14 @@ def sim(
                         f"got {type(result)} for key '{label}'"
                     )
 
+            # Streaming mode: hand the authoritative loop timestamp and the raw
+            # result to the sink and retain nothing. This keeps peak memory flat
+            # for callers that write straight into a preallocated structure.
+            if on_result is not None:
+                on_result(timestamp, result_dict)
+                continue
+
+            for label, result in result_dict.items():
                 # Initialize list for this label if it doesn't exist
                 if label not in results:
                     results[label] = []

--- a/vbase_utils/sim.py
+++ b/vbase_utils/sim.py
@@ -66,7 +66,8 @@ def sim(
         no rows; non-empty results with NaN values do contribute rows.
 
     Raises:
-        ValueError: If any input data object doesn't have a DatetimeIndex.
+        ValueError: If any input data object doesn't have a DatetimeIndex or a
+            MultiIndex whose first level is a DatetimeIndex.
         ValueError: If the callback function doesn't return a dictionary of DataFrames or Series.
         ValueError: If the callback function raises an exception.
     """

--- a/vbase_utils/stats/parallel_robust_betas.py
+++ b/vbase_utils/stats/parallel_robust_betas.py
@@ -90,7 +90,7 @@ def _compute_single_asset_beta(
 
 # The function must take a large number of arguments
 # and consequently has a large number of local variables.
-# pylint: disable=too-many-arguments, too-many-locals
+# pylint: disable=too-many-arguments, too-many-locals, too-many-positional-arguments
 def parallel_robust_betas(
     df_asset_rets: pd.DataFrame,
     df_fact_rets: pd.DataFrame,

--- a/vbase_utils/stats/pit_robust_betas.py
+++ b/vbase_utils/stats/pit_robust_betas.py
@@ -16,7 +16,7 @@ logger.addHandler(logging.NullHandler())
 
 # The function must take a large number of arguments
 # and consequently has a large number of local variables.
-# pylint: disable=too-many-arguments, too-many-locals, too-many-branches
+# pylint: disable=too-many-arguments, too-many-locals, too-many-branches, too-many-positional-arguments
 def pit_robust_betas(
     df_asset_rets: pd.DataFrame,
     df_fact_rets: pd.DataFrame,

--- a/vbase_utils/stats/robust_betas.py
+++ b/vbase_utils/stats/robust_betas.py
@@ -135,9 +135,12 @@ def _validate_beta_inputs(
     # value invalidates the whole date. Skip it (all-NaN betas) rather than
     # raising, so a simulation continues past isolated dirty factor dates.
     if not np.isfinite(df_fact_rets.to_numpy()).all():
+        bad_mask = ~np.isfinite(df_fact_rets.to_numpy())
+        bad_timestamps = df_fact_rets.index[bad_mask.any(axis=1)].tolist()
         logger.warning(
-            "Non-finite (NaN/inf) factor value(s) at %s; skipping date (all-NaN betas).",
-            df_fact_rets.index[-1],
+            "Non-finite (NaN/inf) factor value(s) in regression window at %s; "
+            "skipping (all-NaN betas).",
+            bad_timestamps,
         )
         return n_timestamps, df_betas, False
 

--- a/vbase_utils/stats/robust_betas.py
+++ b/vbase_utils/stats/robust_betas.py
@@ -131,6 +131,16 @@ def _validate_beta_inputs(
         # Return the timestamp count and all-NaN beta matrix.
         return n_timestamps, df_betas, False
 
+    # Non-finite factors (NaN/inf) are shared across all assets, so a single bad
+    # value invalidates the whole date. Skip it (all-NaN betas) rather than
+    # raising, so a simulation continues past isolated dirty factor dates.
+    if not np.isfinite(df_fact_rets.to_numpy()).all():
+        logger.warning(
+            "Non-finite (NaN/inf) factor value(s) at %s; skipping date (all-NaN betas).",
+            df_fact_rets.index[-1],
+        )
+        return n_timestamps, df_betas, False
+
     # Check for near-zero variance in df_fact_rets.
     if df_fact_rets.var().min() < NEAR_ZERO_VARIANCE_THRESHOLD:
         logger.error("One or more factors in df_fact_rets have near-zero variance.")


### PR DESCRIPTION
## Summary

Added support for MultiIndex whose first level is a DatetimeIndex
Added on_result() callback to simulator to improve some sim memory management

## Acknowledgment

- [V] I have performed a **self-review** of my own code.
- [V] I have **tested** the code in my local environment.
- [V] I have **commented my code**, particularly in hard-to-understand areas.

## Checklist

- [V] Existing **Tests** are passing.
- [V] Necessary **Tests** were created or updated.
- [V] Modified **lines of code are formatted**.
