### PR TITLE
Correct three parallel-betas comments

### DIFF
--- a/vbase_utils/stats/_parallel_betas_by_date.py
+++ b/vbase_utils/stats/_parallel_betas_by_date.py
@@ -496,10 +496,15 @@ def _betas_date_parallel(
         )
     finally:
         # Release the parent's memory-mapped file handles before removing the
-        # directory. On Windows, open handles prevent deletion and
-        # ignore_errors=True would silently leak the spill directory across
-        # repeated calls. Workers are shut down by Parallel.__exit__ before
-        # this block runs, so only the parent's handles need explicit release.
+        # directory. On POSIX this is enough: unlinking a file other processes
+        # still have open is legal. On Windows it is not sufficient -- loky's
+        # backend deliberately keeps its workers alive for reuse across calls
+        # (Parallel.__exit__ clears bookkeeping but does not terminate them), so
+        # the workers still hold read-only mmaps here and rmtree raises
+        # PermissionError. The warning below surfaces that leak instead of
+        # hiding it the way ignore_errors=True did; closing it would mean
+        # shutting down the reusable executor and paying pool startup on every
+        # call.
         for key in ("a", "f", "valid", "cs_valid"):
             pc.pop(key, None)
         try:

--- a/vbase_utils/stats/_parallel_betas_by_date_worker.py
+++ b/vbase_utils/stats/_parallel_betas_by_date_worker.py
@@ -169,7 +169,7 @@ def initialize_date_worker(
     logger.debug(
         "initialize_date_worker: pid=%d mapped arrays loaded; n_facts=%d; worker ready",
         os.getpid(),
-        pc.get("n_facts", "?"),
+        pc["n_facts"],
     )
 
 

--- a/vbase_utils/stats/pit_robust_betas.py
+++ b/vbase_utils/stats/pit_robust_betas.py
@@ -125,8 +125,9 @@ def pit_robust_betas(
             asset axis. Over-decomposition evens out the ragged per-date cost --
             a late window is far more expensive than an early one -- at the price
             of more tasks. It also sizes the result payload each task ships back
-            (see ``_parallel_betas_by_date_worker.fit_date_group``), so raising it
-            is a memory decision as well as a scheduling one. Defaults to 4.
+            (see ``_parallel_betas_by_date_worker.fit_date_group``): more blocks
+            means fewer dates per block, so raising it *reduces* peak memory as
+            well as evening out the schedule. Defaults to 4.
         return_hedge_rets_by_fact: Whether to include 'df_hedge_rets_by_fact' in the
             result. Defaults to True. It is the largest frame this function builds, at
             (n_timestamps * n_factors, n_assets), and it cannot be skipped outright --


### PR DESCRIPTION
Three comment/log-accuracy fixes on the date-axis parallel betas path. No behavior change.

- `_parallel_betas_by_date.py` — describe the spill cleanup limits accurately.
- `pit_robust_betas.py` — correct the `blocks_per_worker` memory note.
- `_parallel_betas_by_date_worker.py` — drop the string fallback in the date worker log.

Left `dev` trailing stale docstrings after PR #43; this catches it up before the next full risk-model rebuild.