### PR TITLE
Fix worker startup failures and progress reporting in the parallel betas calculation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Generated from validityBase/github-configuration templates.
-# Do not edit rendered files manually; update templates/ and config/ instead.
+# Do not edit rendered files manually; update the source template in validityBase/github-configuration.
 version: 2
 updates:
   - package-ecosystem: "pip"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,5 @@
+# Generated from validityBase/github-configuration templates.
+# Do not edit rendered files manually; update templates/ and config/ instead.
 version: 2
 updates:
   - package-ecosystem: "pip"
@@ -20,3 +22,8 @@ updates:
         applies-to: "security-updates"
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "pip"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"

--- a/.github/workflows/repo-backup.yml
+++ b/.github/workflows/repo-backup.yml
@@ -1,0 +1,26 @@
+name: Daily Repo Backup
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 2 * * *"  # daily 02:17 UTC
+
+concurrency:
+  group: repo-backup
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  backup:
+    # validityBase-owned shared workflows intentionally use reviewed moving
+    # major tags; see internal/specs/github-actions.md.
+    uses: validityBase/vbase-github-actions/.github/workflows/repo-backup.yml@v1
+    with:
+      backup-prefix: github-backups
+      bundle-name: repo.bundle
+      bitwarden-project: vbase-repo-backups
+    secrets:
+      VBASE_COMMON_REPO_READ_TOKEN: ${{ secrets.VBASE_COMMON_REPO_READ_TOKEN }}
+      BWS_ACCESS_TOKEN: ${{ secrets.VBASE_REPO_BACKUP_SECRETS_TOKEN }}

--- a/internal/agents/memory/MEMORY.md
+++ b/internal/agents/memory/MEMORY.md
@@ -28,6 +28,8 @@ projects.
 - vBase-owned shared actions and reusable workflows use reviewed `validityBase/vbase-github-actions` version tags.
 - Pylint delegates to `validityBase/vbase-github-actions/.github/workflows/python-lint.yml@v1`.
 - Unit tests use `validityBase/vbase-github-actions/.github/actions/setup-python-deps@v1`.
+- Repository backup delegates to `validityBase/vbase-github-actions/.github/workflows/repo-backup.yml@v1`;
+  details stay in `internal/specs/github-actions.md`.
 - `python-dependency-locks.yml` verifies terminal lock freshness, hash installs,
   editable install, and `pip check`.
 - Push branch filters use `"**"` so branches containing `/` are included.

--- a/internal/specs/github-actions.md
+++ b/internal/specs/github-actions.md
@@ -44,3 +44,15 @@ pylint $(git ls-files '*.py')
 - Installs development dependencies through `setup-python-deps@v1`.
 - Installs the package locally with `python -m pip install --no-deps --no-build-isolation -e .`.
 - Runs `python -m unittest discover -s tests`.
+
+### `.github/workflows/repo-backup.yml`
+- Runs daily and through manual dispatch to create a full-history git bundle
+  backup.
+- Delegates to `validityBase/vbase-github-actions/.github/workflows/repo-backup.yml@v1`.
+- Uses reviewed moving major tags for validityBase-owned shared workflows so
+  centrally reviewed fixes roll forward without per-repository pin updates.
+- Requires `VBASE_COMMON_REPO_READ_TOKEN` and
+  `VBASE_REPO_BACKUP_SECRETS_TOKEN` GitHub Actions secrets.
+- Reads object storage credentials from the `vbase-repo-backups` Bitwarden
+  project at runtime; bucket lifecycle and restore-test policy live outside
+  this repository.

--- a/tests/stats/test_parallel_betas_by_date_worker.py
+++ b/tests/stats/test_parallel_betas_by_date_worker.py
@@ -1,0 +1,178 @@
+"""Lifecycle tests for the date-axis worker.
+
+The date-axis equivalence suites assert the numbers a run produces, and both
+would keep passing if the worker opened its arrays eagerly again: the eager
+version returned correct betas and then logged ``FileNotFoundError`` at CRITICAL
+from every worker that started after the parent had finished. What these tests
+pin is therefore the lifecycle rather than the arithmetic -- when the mappings
+are opened, that they are opened once, and that a worker which never receives a
+block never touches the files at all.
+
+The worker is driven directly instead of through ``joblib``. The failure being
+guarded against is a race between worker startup and the parent's cleanup, and a
+pool cannot be made to lose that race on demand; calling the two halves in the
+order the race produces reproduces it exactly and takes no pool to do it.
+"""
+
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+
+from vbase_utils.stats import _parallel_betas_by_date_worker as worker
+from vbase_utils.stats._parallel_betas_by_date import (
+    META_KEYS,
+    SPILL_KEYS,
+    precompute_date_betas,
+)
+from vbase_utils.stats._parallel_betas_by_date_worker import (
+    _G,
+    fit_date_group,
+    initialize_date_worker,
+)
+
+from ._robust_betas_fixtures import make_linear_ret_frames as _make_returns
+
+# Panel size. Long enough that late dates clear MIN_TIMESTAMPS and early ones do
+# not, which is what gives the tests both a fitted and a rejected date.
+N_TIMESTAMPS = 60
+MIN_TIMESTAMPS = 20
+HALF_LIFE = 30.0
+SEED = 11
+
+# Rows used to build the groups sent to the worker. The first is rejected for
+# having fewer than MIN_TIMESTAMPS complete rows behind it; the last has the
+# whole panel behind it and is fit.
+REJECTED_ROW = 0
+FITTED_ROW = N_TIMESTAMPS - 1
+
+
+def _make_precomputed() -> dict:
+    """Return the precomputed inputs for a small two-asset, one-factor panel."""
+    df_asset, df_fact = _make_returns(
+        n=N_TIMESTAMPS,
+        betas={"A": [0.7], "B": [1.3]},
+        factors=["F1"],
+        seed=SEED,
+    )
+    return precompute_date_betas(
+        df_asset_rets=df_asset,
+        df_fact_rets=df_fact,
+        rebalance_time_index=pd.DatetimeIndex(df_asset.index),
+        half_life=HALF_LIFE,
+        lambda_=None,
+        min_timestamps=MIN_TIMESTAMPS,
+    )
+
+
+class TestDateWorkerLifecycle(unittest.TestCase):
+    """The worker records paths at startup and opens the arrays on first use."""
+
+    def setUp(self):
+        pc = _make_precomputed()
+        self.tmpdir = tempfile.mkdtemp(prefix="vbase_date_worker_test_")
+        # Spill exactly what the parallel path spills, through the same key list,
+        # so this test cannot drift from the producer.
+        self.paths = {}
+        for key in SPILL_KEYS:
+            path = os.path.join(self.tmpdir, f"{key}.npy")
+            np.save(path, pc[key])
+            self.paths[key] = path
+        self.meta = {k: pc[k] for k in META_KEYS}
+        self.asset_names = ["A", "B"]
+
+    def tearDown(self):
+        # The worker's state is a module global, so a test that leaves a mapping
+        # behind would hand it to the next one.
+        _G.clear()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_initializer_does_not_open_the_arrays(self):
+        """Startup records the paths and loads nothing."""
+        with patch.object(worker.np, "load") as mock_load:
+            initialize_date_worker(self.paths, self.meta, self.asset_names)
+            mock_load.assert_not_called()
+        self.assertEqual(_G["paths"], self.paths)
+        self.assertNotIn("pc", _G)
+
+    def test_initializer_survives_the_spill_directory_being_gone(self):
+        """A worker that starts after the parent has cleaned up still starts.
+
+        This is the race the lazy opening was introduced for: loky does not wait
+        for the initializer to finish, so a worker could still be starting when
+        the parent had collected every block and removed the spill directory. A
+        worker in that position has no block left to fit, so recording the paths
+        must not depend on the files still being there.
+        """
+        shutil.rmtree(self.tmpdir)
+        initialize_date_worker(self.paths, self.meta, self.asset_names)
+        self.assertNotIn("pc", _G)
+
+    def test_first_group_opens_the_arrays_and_later_groups_reuse_them(self):
+        """The mappings are opened by the first task and then held."""
+        initialize_date_worker(self.paths, self.meta, self.asset_names)
+        group = [(0, FITTED_ROW)]
+
+        fit_date_group(group)
+        opened = _G["pc"]
+        self.assertIsNotNone(opened)
+
+        with patch.object(worker.np, "load") as mock_load:
+            fit_date_group(group)
+            mock_load.assert_not_called()
+        self.assertIs(_G["pc"], opened)
+
+    def test_a_second_initialization_drops_the_previous_mapping(self):
+        """Re-initializing clears the mapping so it cannot outlive its paths."""
+        initialize_date_worker(self.paths, self.meta, self.asset_names)
+        fit_date_group([(0, FITTED_ROW)])
+        self.assertIn("pc", _G)
+
+        initialize_date_worker(self.paths, self.meta, self.asset_names)
+        self.assertNotIn("pc", _G)
+
+
+class TestDateGroupDateCount(unittest.TestCase):
+    """A group reports how many dates it covered, not how many it fit.
+
+    The parent's progress postfix counts dates through this number. Taking it
+    from the returned fits instead undercounts every group holding a rejected
+    date, and reports no progress at all for a run whose dates are all rejected
+    -- which is a real outcome, not a hypothetical one: a build whose panel is
+    too short to clear ``min_timestamps`` fits nothing and must still show its
+    blocks completing.
+    """
+
+    def setUp(self):
+        pc = _make_precomputed()
+        self.tmpdir = tempfile.mkdtemp(prefix="vbase_date_worker_test_")
+        paths = {}
+        for key in SPILL_KEYS:
+            path = os.path.join(self.tmpdir, f"{key}.npy")
+            np.save(path, pc[key])
+            paths[key] = path
+        initialize_date_worker(paths, {k: pc[k] for k in META_KEYS}, ["A", "B"])
+
+    def tearDown(self):
+        _G.clear()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_mixed_group_counts_every_date(self):
+        """One fitted and one rejected date still count as two."""
+        n_dates, fits = fit_date_group([(0, REJECTED_ROW), (1, FITTED_ROW)])
+        self.assertEqual(n_dates, 2)
+        self.assertEqual(len(fits), 1)
+
+    def test_all_rejected_group_counts_its_dates(self):
+        """A group that fits nothing reports the dates it covered."""
+        n_dates, fits = fit_date_group([(0, REJECTED_ROW), (1, REJECTED_ROW)])
+        self.assertEqual(n_dates, 2)
+        self.assertEqual(fits, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vbase_utils/stats/_parallel_betas_by_date.py
+++ b/vbase_utils/stats/_parallel_betas_by_date.py
@@ -378,15 +378,38 @@ def _betas_serial(
     """
     n_facts = pc["n_facts"]
     items = [(r, int(i)) for r, i in enumerate(pc["pos"]) if i >= 0]
-    iterator = _progress_iter(items, progress, "Fitting dates", "date")
+    iterator = _progress_iter(
+        items,
+        progress,
+        "Calculating betas/residuals over dates (single process)",
+        "dates",
+        total=len(items),
+    )
     for r, i in iterator:
         cols, params = fit_date(pc, i)
         if params is not None and cols.size:
             _write_block(buf, r, n_facts, cols, params)
 
 
-def _progress_iter(iterable, progress: bool, desc: str, unit: str):
-    """Wrap ``iterable`` in tqdm when requested; otherwise return it unchanged."""
+# The bar's layout. Spelled out rather than left to tqdm's default so the count
+# reads as a sentence ("37 of 384 blocks complete") and so the unit is separated
+# from the number -- the default renders an unknown-total bar as "0block", which
+# says neither how much work there is nor that any is left.
+PROGRESS_BAR_FORMAT = (
+    "{desc}: {n_fmt} of {total_fmt} {unit} complete "
+    "[{elapsed}<{remaining}, {rate_fmt}{postfix}]"
+)
+
+
+def _progress_iter(
+    iterable, progress: bool, desc: str, unit: str, total: Optional[int] = None
+):
+    """Wrap ``iterable`` in tqdm when requested; otherwise return it unchanged.
+
+    ``total`` is passed explicitly because the parallel path iterates a joblib
+    result *generator*, which has no length: without it tqdm cannot show how much
+    work remains or estimate a finish time.
+    """
     if not progress:
         return iterable
     # Import only when needed, so callers that do not request a progress bar do
@@ -394,7 +417,9 @@ def _progress_iter(iterable, progress: bool, desc: str, unit: str):
     # pylint: disable=import-outside-toplevel
     from tqdm import tqdm
 
-    return tqdm(iterable, desc=desc, unit=unit)
+    return tqdm(
+        iterable, desc=desc, unit=unit, total=total, bar_format=PROGRESS_BAR_FORMAT
+    )
 
 
 def _betas_date_parallel(
@@ -477,15 +502,29 @@ def _betas_date_parallel(
                 len(blocks),
             )
             results = par(delayed(fit_date_group)(b) for b in blocks)
-            # The progress bar counts blocks, not dates. The date loop runs in
-            # workers, so the parent cannot report progress for individual dates.
-            for blk in _progress_iter(
-                results, progress, "Fitting date blocks", "block"
-            ):
+            # The bar counts blocks, not dates: the date loop runs in workers, so
+            # the parent learns nothing until a whole block comes back. The dates
+            # a block covers are known once it returns, so they are carried in the
+            # postfix -- blocks measure the schedule, dates measure the work.
+            n_dates = sum(len(b) for b in blocks)
+            n_dates_done = 0
+            iterator = _progress_iter(
+                results,
+                progress,
+                "Calculating betas/residuals in parallel over dates",
+                "blocks",
+                total=len(blocks),
+            )
+            for blk in iterator:
                 for r, cols, params in blk:
                     _write_block(buf, r, n_facts, cols, params)
+                n_dates_done += len(blk)
                 del blk
                 n_completed += 1
+                if progress:
+                    iterator.set_postfix_str(
+                        f"{n_dates_done}/{n_dates} dates", refresh=False
+                    )
                 logger.debug(
                     "date_parallel: block %d/%d done", n_completed, len(blocks)
                 )
@@ -497,7 +536,10 @@ def _betas_date_parallel(
     finally:
         # Release the parent's memory-mapped file handles before removing the
         # directory. On POSIX this is enough: unlinking a file other processes
-        # still have open is legal. On Windows it is not sufficient -- loky's
+        # still have open is legal, and a worker that has not opened the files
+        # yet never will -- initialize_date_worker only records the paths and
+        # the first task opens them, so a worker still warming up here has no
+        # block left to fit. On Windows it is not sufficient -- loky's
         # backend deliberately keeps its workers alive for reuse across calls
         # (Parallel.__exit__ clears bookkeeping but does not terminate them), so
         # the workers still hold read-only mmaps here and rmtree raises

--- a/vbase_utils/stats/_parallel_betas_by_date.py
+++ b/vbase_utils/stats/_parallel_betas_by_date.py
@@ -59,6 +59,15 @@ from vbase_utils.stats.robust_betas import (
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
+# The precomputed entries written to disk for the workers to memory-map. Named
+# here rather than inside the parallel path so tests exercising a worker spill
+# the same set the parallel path does.
+SPILL_KEYS = ("a", "f", "valid", "cs_valid", "pw", "date_ok")
+
+# The entries passed to the workers by value. They are scalars, so sending a
+# copy to each worker costs nothing.
+META_KEYS = ("n_facts", "min_timestamps")
+
 
 def _check_spill_target(spill_dir: str, n_bytes: int) -> None:
     """Warn if the temporary files may not fit in their directory.
@@ -441,8 +450,7 @@ def _betas_date_parallel(
     from joblib import Parallel, delayed, effective_n_jobs
 
     eff = effective_n_jobs(n_jobs)
-    spill_keys = ("a", "f", "valid", "cs_valid", "pw", "date_ok")
-    n_bytes = sum(int(pc[key].nbytes) for key in spill_keys)
+    n_bytes = sum(int(pc[key].nbytes) for key in SPILL_KEYS)
     tmpdir = tempfile.mkdtemp(prefix="vbase_date_betas_")
     logger.debug(
         "date_parallel: n_jobs=%d eff=%d n_assets=%d spill=%.0fMB tmpdir=%s",
@@ -456,14 +464,14 @@ def _betas_date_parallel(
         _check_spill_target(tmpdir, n_bytes)
         paths = {}
         t_spill = time.monotonic()
-        for key in spill_keys:
+        for key in SPILL_KEYS:
             path = os.path.join(tmpdir, f"{key}.npy")
             np.save(path, pc[key])
             paths[key] = path
         logger.debug(
             "date_parallel: panel spilled to disk in %.2fs", time.monotonic() - t_spill
         )
-        meta = {k: pc[k] for k in ("n_facts", "min_timestamps")}
+        meta = {k: pc[k] for k in META_KEYS}
 
         # Reopen the arrays as read-only memory-mapped files. The operating
         # system can share the same cached pages among workers, so the arrays
@@ -506,6 +514,11 @@ def _betas_date_parallel(
             # the parent learns nothing until a whole block comes back. The dates
             # a block covers are known once it returns, so they are carried in the
             # postfix -- blocks measure the schedule, dates measure the work.
+            #
+            # The count comes back with the block rather than being taken from
+            # the results, which hold only the dates that produced betas: a run
+            # whose dates are all rejected returns no results at all and would
+            # otherwise report no progress while completing every block.
             n_dates = sum(len(b) for b in blocks)
             n_dates_done = 0
             iterator = _progress_iter(
@@ -515,10 +528,10 @@ def _betas_date_parallel(
                 "blocks",
                 total=len(blocks),
             )
-            for blk in iterator:
+            for n_dates_in_block, blk in iterator:
                 for r, cols, params in blk:
                     _write_block(buf, r, n_facts, cols, params)
-                n_dates_done += len(blk)
+                n_dates_done += n_dates_in_block
                 del blk
                 n_completed += 1
                 if progress:

--- a/vbase_utils/stats/_parallel_betas_by_date_worker.py
+++ b/vbase_utils/stats/_parallel_betas_by_date_worker.py
@@ -136,12 +136,18 @@ _G: Dict[str, Any] = {}
 def initialize_date_worker(
     paths: Dict[str, str], meta: Dict[str, Any], asset_names: Optional[List[str]] = None
 ) -> None:
-    """Load read-only arrays once per worker and prepare the fit code.
+    """Record where the shared arrays are and prepare the fit code.
 
-    ``mmap_mode="r"`` opens the arrays as read-only memory-mapped files. The
-    operating system can share the same cached memory pages among workers, so
-    the arrays need only one physical copy. Each task sends only a list of
-    integer positions rather than the arrays themselves.
+    The arrays are not opened here. loky starts every worker at once and does
+    not wait for this function to finish, so a worker can still be warming up
+    when the parent has collected every block and removed the spill directory in
+    its ``finally``. Opening the files here would then fail with
+    ``FileNotFoundError`` in a process that never had work to do. Opening them
+    in the first task instead means a worker touches the files only when it has
+    a block to fit, and blocks always complete before the parent cleans up.
+    Measured at 32 workers on a run whose dates were all rejected: 27-29 workers
+    failed this way before the change and none after, with no change in fit time
+    or peak memory.
 
     ``joblib.Parallel(n_jobs=1)`` uses its sequential mode and does not call the
     worker setup function. The calling module therefore handles that case with
@@ -157,20 +163,48 @@ def initialize_date_worker(
     # initialize_asset_worker has configured the worker's logging handlers.
     n_assets = len(asset_names) if asset_names is not None else 0
     logger.debug(
-        "initialize_date_worker: pid=%d loading %d mapped arrays; n_assets=%d",
+        "initialize_date_worker: pid=%d recorded %d array paths; n_assets=%d; "
+        "worker ready",
         os.getpid(),
         len(paths),
         n_assets,
     )
-    pc: Dict[str, Any] = {k: np.load(p, mmap_mode="r") for k, p in paths.items()}
-    pc.update(meta)
-    pc["asset_names"] = asset_names
+    _G["paths"] = paths
+    _G["meta"] = meta
+    _G["asset_names"] = asset_names
+    # A worker is initialized once per process, but clear any previous mapping
+    # so a stale one can never outlive the paths it was opened from.
+    _G.pop("pc", None)
+
+
+def _precomputed() -> Dict[str, Any]:
+    """Return this worker's precomputed inputs, opening the arrays on first use.
+
+    ``mmap_mode="r"`` opens the arrays as read-only memory-mapped files. The
+    operating system can share the same cached memory pages among workers, so
+    the arrays need only one physical copy. Each task sends only a list of
+    integer positions rather than the arrays themselves. Opening a mapping reads
+    no data, so the first task pays only the cost of the ``open`` calls.
+    """
+    pc = _G.get("pc")
+    if pc is not None:
+        return pc
+    paths = _G["paths"]
+    logger.debug(
+        "date worker: pid=%d loading %d mapped arrays",
+        os.getpid(),
+        len(paths),
+    )
+    pc = {k: np.load(p, mmap_mode="r") for k, p in paths.items()}
+    pc.update(_G["meta"])
+    pc["asset_names"] = _G["asset_names"]
     _G["pc"] = pc
     logger.debug(
-        "initialize_date_worker: pid=%d mapped arrays loaded; n_facts=%d; worker ready",
+        "date worker: pid=%d mapped arrays loaded; n_facts=%d",
         os.getpid(),
         pc["n_facts"],
     )
+    return pc
 
 
 def fit_date_group(
@@ -189,7 +223,7 @@ def fit_date_group(
     fewer dates per group and a smaller payload). Lowering ``blocks_per_worker``
     therefore increases memory use per result; raising it reduces it.
     """
-    pc = _G["pc"]
+    pc = _precomputed()
     t0 = time.monotonic()
     n_dates = len(rows_and_positions)
     first_row = rows_and_positions[0][1] if rows_and_positions else -1

--- a/vbase_utils/stats/_parallel_betas_by_date_worker.py
+++ b/vbase_utils/stats/_parallel_betas_by_date_worker.py
@@ -209,8 +209,13 @@ def _precomputed() -> Dict[str, Any]:
 
 def fit_date_group(
     rows_and_positions: Sequence[Tuple[int, int]],
-) -> List[Tuple[int, NDArray[np.intp], NDArray[np.floating]]]:
-    """Fit a group of rebalance dates and return ``[(row, cols, params)]``.
+) -> Tuple[int, List[Tuple[int, NDArray[np.intp], NDArray[np.floating]]]]:
+    """Fit a group of dates and return ``(n_dates, [(row, cols, params)])``.
+
+    The number of dates the group covers is returned alongside the fits because
+    the list holds only the dates that produced betas: a rejected date and a
+    date whose fit failed are both absent from it. The caller uses the count to
+    report progress, and cannot recover it from the results.
 
     Each fitted date returns an ``n_facts x len(cols)`` float64 array. A group's
     result size is therefore approximately:
@@ -261,4 +266,4 @@ def fit_date_group(
         len(out),
         time.monotonic() - t0,
     )
-    return out
+    return n_dates, out


### PR DESCRIPTION
Two problems showed up on full builds of the date-parallel betas path, neither affecting results:

  1. Runs ended with 27–29 of 32 workers logging FileNotFoundError at CRITICAL, even though the run had already produced its betas.
  2. The parallel progress bar displayed 0block for the first ~14 minutes of a build, with no total and no ETA.

###  Worker startup no longer races the parent's cleanup

  initialize_date_worker opened the memory-mapped spill arrays at worker startup. loky starts every worker at once and does not wait for the initializer to finish, so a worker could still be warming up after the parent had collected every block and removed the spill directory in its finally. That worker then failed to open arrays it never had work to read, and died loudly.

  The initializer now only records the paths and clears any stale mapping; the arrays are opened lazily by _precomputed() on the first task that needs them. A worker touches the files only when it has a block to fit, and blocks always complete before the parent cleans up. Opening a mapping reads no data, so the first task pays only the open calls.

  Measured at 32 workers on a run whose dates were all rejected: 27–29 workers failed this way before, none after, with no change in fit time or peak memory. The cleanup comment in _betas_date_parallel is updated to state why the POSIX case is now safe.

###  Progress bar reports blocks and dates

  The parallel bar wrapped a joblib result generator, which has no length, so tqdm counted up from zero with no total and no estimate — and every worker is busy on its first block for the first fourteen minutes of a full build, so the bar read 0block that whole time.

  _progress_iter now takes an explicit total and a spelled-out bar_format, so the bar reads as 37 of 384 blocks complete [elapsed<remaining, rate]. Blocks measure the schedule rather than the work, so the number of dates completed rides alongside in the postfix, updated as each block returns. The single-process path gets the same treatment and a clearer description.

##  Scope
  Progress reporting and worker lifecycle only. No change to the fit, the block scheduling, memory behavior, or any produced betas/residuals.